### PR TITLE
Fix compile error when using unity.entities 1.2.x

### DIFF
--- a/MagicTween/Assets/MagicTween/Runtime/Core/Systems/PathTweenSystems.cs
+++ b/MagicTween/Assets/MagicTween/Runtime/Core/Systems/PathTweenSystems.cs
@@ -57,7 +57,7 @@ namespace MagicTween.Core.Systems
             accessorFlagsTypeHandle = SystemAPI.GetComponentTypeHandle<TweenAccessorFlags>(true);
             pointsTypeHandle = SystemAPI.GetBufferTypeHandle<PathPoint>();
             valueTypeHandle = SystemAPI.GetComponentTypeHandle<TweenValue<float3>>();
-            accessorTypeHandle = SystemAPI.ManagedAPI.GetComponentTypeHandle<TweenDelegates<float3>>(true);
+            accessorTypeHandle = EntityManager.GetComponentTypeHandle<TweenDelegates<float3>>(true);
         }
 
         [BurstCompile]

--- a/MagicTween/Assets/MagicTween/Runtime/Core/Systems/StringTweenSystems.cs
+++ b/MagicTween/Assets/MagicTween/Runtime/Core/Systems/StringTweenSystems.cs
@@ -86,7 +86,7 @@ namespace MagicTween.Core.Systems
             accessorFlagsTypeHandle = SystemAPI.GetComponentTypeHandle<TweenAccessorFlags>(true);
             startValueTypeHandle = SystemAPI.GetComponentTypeHandle<TweenStartValue<UnsafeText>>();
             valueTypeHandle = SystemAPI.GetComponentTypeHandle<TweenValue<UnsafeText>>();
-            accessorTypeHandle = SystemAPI.ManagedAPI.GetComponentTypeHandle<TweenDelegates<string>>(true);
+            accessorTypeHandle = EntityManager.GetComponentTypeHandle<TweenDelegates<string>>(true);
         }
 
         protected override void OnUpdate()

--- a/MagicTween/Assets/MagicTween/Runtime/Core/Systems/TweenDelegateTranslationSystemBase.cs
+++ b/MagicTween/Assets/MagicTween/Runtime/Core/Systems/TweenDelegateTranslationSystemBase.cs
@@ -43,8 +43,8 @@ namespace MagicTween.Core.Systems
             accessorFlagsTypeHandle = SystemAPI.GetComponentTypeHandle<TweenAccessorFlags>(true);
             startValueTypeHandle = SystemAPI.GetComponentTypeHandle<TweenStartValue<TValue>>();
             valueTypeHandle = SystemAPI.GetComponentTypeHandle<TweenValue<TValue>>();
-            delegatesTypeHandle = SystemAPI.ManagedAPI.GetComponentTypeHandle<TweenDelegates<TValue>>(true);
-            unsafedelegatesTypeHandle = SystemAPI.ManagedAPI.GetComponentTypeHandle<TweenDelegatesNoAlloc<TValue>>(true);
+            delegatesTypeHandle = EntityManager.GetComponentTypeHandle<TweenDelegates<TValue>>(true);
+            unsafedelegatesTypeHandle = EntityManager.GetComponentTypeHandle<TweenDelegatesNoAlloc<TValue>>(true);
         }
 
 


### PR DESCRIPTION
The SystemAPI.ManagedAPI.GetComponentTypeHandle appears to have a bug in 1.2.x which causes an error when compiling. Replaced with EntityManager.GetComponentTypeHandle which does not have this bug.

Ran tests with both unity.entities 1.0.14 and 1.2.3 in Unity 2022.3.7f and 2023.3.19f and all passed.